### PR TITLE
Fix markdown hyperlink syntax typo

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,6 @@
 # Parking Organization 
 
-On October 1st, 2022 the `github.com/kris-nova` user was renamed to [@krisnova](https://github.com/krisnova]
+On October 1st, 2022 the `github.com/kris-nova` user was renamed to [@krisnova](https://github.com/krisnova)
 
 In order to stay in control of the space, this organization `github.com/kris-nova` was created and "parked" in this spot.
 


### PR DESCRIPTION
The hyperlink currently points to a 404 at https://github.com/krisnova%5D